### PR TITLE
add github actions config to run tests on PRs

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  pytests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install package
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --no-cache-dir --editable .[dev]
+        python -m pip install --no-cache-dir codecov
+    - name: Lint
+      run: flake8 cipher
+    - name: Check types
+      run: mypy cipher
+    - name: Run tests
+      run: pytest cipher
+    - name: Get code coverage
+      run: codecov


### PR DESCRIPTION
This configuration runs the python tests in the repository in multiple
versions of python. This is helpful to make sure that PRs don't break
existing code, and if tests are included with new code, that those tests
pass.