### PR TITLE
[TST] model zoo tests

### DIFF
--- a/cipher/model_zoo/__init__.py
+++ b/cipher/model_zoo/__init__.py
@@ -1,6 +1,32 @@
-from . import deepbind  # noqa: F401
 from . import cnn_dist  # noqa: F401
 from . import cnn_local  # noqa: F401
+from . import deepbind  # noqa: F401
 from . import deepbind_custom  # noqa: F401
 from . import residualbind  # noqa: F401
 
+
+def get_model(name: str):
+    """Return function that can be used to instantiate a model architecture.
+
+    Parameters
+    ----------
+    name : str
+        Name of the model architecture.
+
+    Returns
+    -------
+    Callable
+        Function that can be used to instantiate a model architecture.
+    """
+    models = {
+        "cnn_dist": cnn_dist.model,
+        "cnn_local": cnn_local.model,
+        "deepbind": deepbind.model,
+        "deepbind_custom": deepbind_custom.model,
+        "residualbind": residualbind.model,
+    }
+    try:
+        return models[name.lower()]
+    except KeyError:
+        ms = "', '".join(models.keys())
+        raise KeyError(f"Unknown model name '{name}'. Available models are '{ms}'.")

--- a/cipher/model_zoo/tests/test_models.py
+++ b/cipher/model_zoo/tests/test_models.py
@@ -1,0 +1,60 @@
+import pytest
+import numpy as np
+
+from cipher.model_zoo import cnn_dist
+from cipher.model_zoo import cnn_local
+from cipher.model_zoo import deepbind
+from cipher.model_zoo import deepbind_custom
+from cipher.model_zoo import get_model
+from cipher.model_zoo import residualbind
+
+
+@pytest.mark.parametrize(
+    "name,model_fn,error",
+    [
+        ("cnn_dist", cnn_dist.model, None),
+        ("cnn_local", cnn_local.model, None),
+        ("deepbind", deepbind.model, None),
+        ("deepbind_custom", deepbind_custom.model, None),
+        ("residualbind", residualbind.model, None),
+        ("fakemodel", None, KeyError),
+    ],
+)
+def test_get_model(name: str, model_fn, error):
+    if error is not None:
+        with pytest.raises(error):
+            get_model(name)
+    else:
+        assert get_model(name) is model_fn
+        assert get_model(name.upper()) is model_fn
+
+
+@pytest.mark.parametrize(
+    "model_fn,x_shape",
+    [
+        pytest.param(cnn_dist.model, (100, 4), id="cnn_dist"),
+        pytest.param(cnn_local.model, (100, 4), id="cnn_local"),
+        pytest.param(deepbind.model, (10, 4), id="deepbind"),
+        pytest.param(deepbind_custom.model, (10, 4), id="deepbind_custom"),
+        pytest.param(residualbind.model, (10, 4), id="residualbind"),
+    ],
+)
+def test_model_fit_required_args_only(model_fn, x_shape):
+    rng = np.random.default_rng()
+    # batch size 2, 24-nt sequence, alphabet length 4.
+    x = rng.uniform(size=[2, *x_shape])
+    # shape (2, 2). 2 sequences, 2 classes.
+    y = np.array(
+        [[0, 1], [1, 0]],
+        dtype=np.float32,
+    )
+    model = model_fn(input_shape=x_shape, output_shape=2)
+    model.compile(optimizer="sgd", loss="binary_crossentropy")
+    model.fit(x, y)
+
+
+@pytest.mark.xfail
+def test_models_bad_args():
+    # TODO: test that model funcs raise useful errors when passing invalid args.
+    #   For example, error on bad length of list arguments.
+    raise NotImplementedError()

--- a/cipher/train.py
+++ b/cipher/train.py
@@ -1,31 +1,24 @@
 import argparse
+
 import pandas as pd
 from tensorflow import keras
+
 from cipher import load
+from cipher.model_zoo import get_model
 
 
 def main(model_name, data_path, args):
 
     # Load data
-    x_train, y_train, x_valid, y_valid, x_test, y_test = load.standard_data(
+    x_train, y_train, x_valid, y_valid, _, _ = load.standard_data(
         data_path, reverse_comp=args.rc
-    )
-
-    # Import model from the zoo as singular animal
-    # equivalent of `from model_zoo import model_name as animal` where model_name is
-    # evaluated at runtime.
-
-    # TODO: this code is difficult to understand. If there is buggy behavior related to
-    # this line, it will be difficult to debug. I propose refactoring this to use a
-    # method that grabs the model function from a dictionary of the known models.
-    animal = __import__(
-        "cipher.model_zoo." + model_name, globals(), locals(), [model_name], 0
     )
 
     # Build model
     num_labels = y_train.shape[1]
     N, L, A = x_train.shape
-    model = animal.model(input_shape=(L, A), output_shape=num_labels)
+    model_fn = get_model(model_name)
+    model = model_fn(input_shape=(L, A), output_shape=num_labels)
 
     # set up optimizer and metrics
     auroc = keras.metrics.AUC(curve="ROC", name="auroc")

--- a/cipher/utils.py
+++ b/cipher/utils.py
@@ -32,7 +32,7 @@ def make_directory(dirpath, verbose=1):
 
 
 def import_model(model_name):
-    """Import a model from model_zoo. 
+    """Import a model from model_zoo.
 
     Parameters
     ----------
@@ -41,7 +41,7 @@ def import_model(model_name):
 
     Returns
     -------
-        imported model 
+        imported model
 
     Examples
     --------
@@ -52,5 +52,7 @@ def import_model(model_name):
 
     # Import model from the zoo as singular animal
     # Equivalent of `from model_zoo import model_name as animal` where model_name is evaluated at runtime
-    animal = __import__("cipher.model_zoo." + model_name, globals(), locals(), [model_name], 0) 
+    animal = __import__(
+        "cipher.model_zoo." + model_name, globals(), locals(), [model_name], 0
+    )
     return animal


### PR DESCRIPTION
This PR adds minimal tests of the model zoo. It also adds a function `cipher.model_zoo.get_model` to get a model func from a string name. I realize a similar function was added in https://github.com/p-koo/cipher/commit/da36e08f61d9506bd1815a6ee643019d8366a380