### PR TITLE
add pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+-   repo: https://github.com/psf/black
+    rev: 19.3b0
+    hooks:
+    -   id: black
+-   repo: https://gitlab.com/PyCQA/flake8
+    rev: "3.8.4"
+    hooks:
+    -   id: flake8

--- a/README.md
+++ b/README.md
@@ -35,12 +35,11 @@ python -m pip install --no-cache-dir --upgrade pip setuptools wheel
 python -m pip install --no-cache-dir --editable .[dev] tensorflow
 ```
 
-## Code formatting
+It is also useful to use `pre-commit` to run the styler (`black`) and lint the code on
+every commit.
 
-Format your code with `black`.
-
-```bash
-black cipher
+```
+pre-commit
 ```
 
 ## Running tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ dev =
     black
     flake8
     mypy
+    pre-commit
     pytest
     pytest-cov
 doc =


### PR DESCRIPTION
This runs the black styler and flake8 linter on every commit.

Can be useful because then we maintain style on each commit. And the authors of the commit are given attribution for that.